### PR TITLE
Adding more spleep time for docker restart

### DIFF
--- a/.github/workflows/cypress-UI.yml
+++ b/.github/workflows/cypress-UI.yml
@@ -94,8 +94,8 @@ jobs:
         cd ${{ env.PATH_TEMPLATE_XPACK_CLUSTER_AGENT }}
         docker exec es_xpack-wz_cluster-agent_kibana_1 bin/kibana-plugin install file:///packages/$PACKAGE_NAME
         sudo docker-compose restart kibana
-        echo CONTINUES AFTER 20 SECONDS ...
-        sleep 30s
+        echo CONTINUES AFTER 60 SECONDS ...
+        sleep 60s
      - name: Step 08 - Configuring ip container into wazuh.yml
        if: ${{ env.RUN_TEST == 'true' }}
        run: |


### PR DESCRIPTION
There is a problem during the execution of the  github action. The restart of the kibana container is to slow. So I modified the sleep time between the container restart and the search of the wazuh.yml file